### PR TITLE
fixed- change slug endpoint for a more explicit path

### DIFF
--- a/api/polls.js
+++ b/api/polls.js
@@ -48,7 +48,7 @@ router.get("/draft", authenticateJWT, async (req, res) => {
 });
 
 // Get polls by slug
-router.get("/:slug", authenticateJWT, async (req, res) => {
+router.get("/slug/:slug", authenticateJWT, async (req, res) => {
     try {
         const pollSlug = req.params.slug;
         const poll = await Poll.findOne({


### PR DESCRIPTION
- Changed path for slug API Endpoint for a better separation between  endpoints
- OG--> api/polls/:id
- Slug---> api/polls/slug/:slug