### PR TITLE
Allow Authenticated Users to Delete Any Owned Poll

### DIFF
--- a/api/polls.js
+++ b/api/polls.js
@@ -220,22 +220,14 @@ router.delete("/:id", authenticateJWT, async (req, res) => {
     }
 
     if (poll.userId !== userId) {
-      return res
-        .status(401)
-        .json({ error: "Unauthorized action: You do not own this poll" });
-    }
-
-    if (poll.status !== "draft") {
-      return res.status(401).json({
-        error: "Unauthorized action: Only draft polls can be deleted",
-      });
+      return res.status(401).json({ error: "Unauthorized action: You do not own this poll" });
     }
 
     await poll.destroy();
 
-    res.json({ message: "Draft poll deleted successfully" });
+    res.json({ message: "Poll deleted successfully" });
   } catch (error) {
-    res.status(500).json({ error: "Failed to delete draft poll" });
+    res.status(500).json({ error: "Failed to delete poll" });
   }
 });
 


### PR DESCRIPTION
updated DELETE /api/polls/:id route to allow users to delete any poll they own, regardless of status
removed status check for efficient deletion
guests (users without userId) cannot delete polls
returns proper error for unauthorized or missing polls